### PR TITLE
Fix dark color when using premultiplied alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_spine"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Spine runtime for Rust (and wasm!) transpiled from the official C Runtime."
 homepage = "https://github.com/jabuwu/rusty_spine"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# 0.7.1 (UNRELEASED)
+- Fix dark color applying incorrectly when using premultiplied alpha
+
 # 0.7.0
 - Add `AttachmentLoader` for creating region attachments
 - Upstream fixes

--- a/src/color.rs
+++ b/src/color.rs
@@ -131,6 +131,19 @@ impl Color {
     }
 }
 
+impl Mul<f32> for Color {
+    type Output = Color;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        Color {
+            r: self.r * rhs,
+            g: self.g * rhs,
+            b: self.b * rhs,
+            a: self.a * rhs,
+        }
+    }
+}
+
 impl Mul<Color> for Color {
     type Output = Color;
 
@@ -141,6 +154,15 @@ impl Mul<Color> for Color {
             b: self.b * rhs.b,
             a: self.a * rhs.a,
         }
+    }
+}
+
+impl MulAssign<f32> for Color {
+    fn mul_assign(&mut self, rhs: f32) {
+        self.r *= rhs;
+        self.g *= rhs;
+        self.b *= rhs;
+        self.a *= rhs;
     }
 }
 

--- a/src/draw/combined.rs
+++ b/src/draw/combined.rs
@@ -198,6 +198,7 @@ impl CombinedDrawer {
                     .dark_color()
                     .unwrap_or_else(|| Color::new_rgba(0.0, 0.0, 0.0, 0.0));
                 if self.premultiplied_alpha {
+                    dark_color *= color.a;
                     dark_color.a = 1.0;
                     dark_color.premultiply_alpha();
                 }
@@ -285,6 +286,7 @@ impl CombinedDrawer {
                     .dark_color()
                     .unwrap_or_else(|| Color::new_rgba(0.0, 0.0, 0.0, 0.0));
                 if self.premultiplied_alpha {
+                    dark_color *= color.a;
                     dark_color.a = 1.0;
                     dark_color.premultiply_alpha();
                 } else {

--- a/src/draw/combined.rs
+++ b/src/draw/combined.rs
@@ -1,4 +1,4 @@
-use crate::{c::c_void, BlendMode, Color, Skeleton, SkeletonClipping};
+use crate::{c::c_void, BlendMode, Skeleton, SkeletonClipping};
 
 use super::{ColorSpace, CullDirection};
 
@@ -186,21 +186,19 @@ impl CombinedDrawer {
                 slot.attachment().and_then(|a| a.as_mesh())
             {
                 let mut color = mesh_attachment.color() * slot.color() * skeleton.color();
+                let mut dark_color = slot.dark_color().unwrap_or_default();
                 if self.premultiplied_alpha {
                     color.premultiply_alpha();
+                    dark_color *= color.a;
+                    dark_color.a = 1.0;
+                } else {
+                    dark_color.a = 0.;
                 }
                 color = match self.color_space {
                     ColorSpace::SRGB => color,
                     ColorSpace::Linear => color.nonlinear_to_linear(),
                 };
 
-                let mut dark_color = slot
-                    .dark_color()
-                    .unwrap_or_else(|| Color::new_rgba(0.0, 0.0, 0.0, 0.0));
-                if self.premultiplied_alpha {
-                    dark_color *= color.a;
-                    dark_color.a = 1.0;
-                }
                 dark_color = match self.color_space {
                     ColorSpace::SRGB => dark_color,
                     ColorSpace::Linear => dark_color.nonlinear_to_linear(),
@@ -273,23 +271,19 @@ impl CombinedDrawer {
                 (color, dark_color)
             } else if let Some(region_attachment) = slot.attachment().and_then(|a| a.as_region()) {
                 let mut color = region_attachment.color() * slot.color() * skeleton.color();
+                let mut dark_color = slot.dark_color().unwrap_or_default();
                 if self.premultiplied_alpha {
                     color.premultiply_alpha();
+                    dark_color *= color.a;
+                    dark_color.a = 1.0;
+                } else {
+                    dark_color.a = 0.;
                 }
                 color = match self.color_space {
                     ColorSpace::SRGB => color,
                     ColorSpace::Linear => color.nonlinear_to_linear(),
                 };
 
-                let mut dark_color = slot
-                    .dark_color()
-                    .unwrap_or_else(|| Color::new_rgba(0.0, 0.0, 0.0, 0.0));
-                if self.premultiplied_alpha {
-                    dark_color *= color.a;
-                    dark_color.a = 1.0;
-                } else {
-                    dark_color.a = 0.0;
-                }
                 dark_color = match self.color_space {
                     ColorSpace::SRGB => dark_color,
                     ColorSpace::Linear => dark_color.nonlinear_to_linear(),

--- a/src/draw/combined.rs
+++ b/src/draw/combined.rs
@@ -200,7 +200,6 @@ impl CombinedDrawer {
                 if self.premultiplied_alpha {
                     dark_color *= color.a;
                     dark_color.a = 1.0;
-                    dark_color.premultiply_alpha();
                 }
                 dark_color = match self.color_space {
                     ColorSpace::SRGB => dark_color,
@@ -288,7 +287,6 @@ impl CombinedDrawer {
                 if self.premultiplied_alpha {
                     dark_color *= color.a;
                     dark_color.a = 1.0;
-                    dark_color.premultiply_alpha();
                 } else {
                     dark_color.a = 0.0;
                 }

--- a/src/draw/simple.rs
+++ b/src/draw/simple.rs
@@ -284,23 +284,19 @@ impl SimpleDrawer {
                 );
 
             color *= slot.color() * skeleton.color();
+            let mut dark_color = slot.dark_color().unwrap_or_default();
             if self.premultiplied_alpha {
                 color.premultiply_alpha();
+                dark_color *= color.a;
+                dark_color.a = 1.0;
+            } else {
+                dark_color.a = 0.;
             }
             color = match self.color_space {
                 ColorSpace::SRGB => color,
                 ColorSpace::Linear => color.nonlinear_to_linear(),
             };
 
-            let mut dark_color = slot
-                .dark_color()
-                .unwrap_or_else(|| Color::new_rgba(0.0, 0.0, 0.0, 0.0));
-            if self.premultiplied_alpha {
-                dark_color *= color.a;
-                dark_color.a = 1.0;
-            } else {
-                dark_color.a = 0.0;
-            }
             dark_color = match self.color_space {
                 ColorSpace::SRGB => dark_color,
                 ColorSpace::Linear => dark_color.nonlinear_to_linear(),

--- a/src/draw/simple.rs
+++ b/src/draw/simple.rs
@@ -298,7 +298,6 @@ impl SimpleDrawer {
             if self.premultiplied_alpha {
                 dark_color *= color.a;
                 dark_color.a = 1.0;
-                dark_color.premultiply_alpha();
             } else {
                 dark_color.a = 0.0;
             }

--- a/src/draw/simple.rs
+++ b/src/draw/simple.rs
@@ -296,6 +296,7 @@ impl SimpleDrawer {
                 .dark_color()
                 .unwrap_or_else(|| Color::new_rgba(0.0, 0.0, 0.0, 0.0));
             if self.premultiplied_alpha {
+                dark_color *= color.a;
                 dark_color.a = 1.0;
                 dark_color.premultiply_alpha();
             } else {


### PR DESCRIPTION
Dark color must be premultiplied by the slot color's alpha. Also removed unnecessary calls to `premultiply_alpha` immediately after setting alpha to 1.