### PR TITLE
Feat/track time mut

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_spine"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "Spine runtime for Rust (and wasm!) transpiled from the official C Runtime."
 homepage = "https://github.com/jabuwu/rusty_spine"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.8.0
+- use `c_accessor_mut!` for TrackEntry's `track_time`.  It is supposed to be mutable according
+to the documentation
+
 # 0.7.1
 - Fix dark color applying incorrectly with premultiplied alpha (using draw functions)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,5 @@
-# 0.8.0
-- use `c_accessor_mut!` for TrackEntry's `track_time`.  It is supposed to be mutable according
-to the documentation
+# 0.8.0 (UNRELEASED)
+- Add `TrackEntry::set_track_time`
 
 # 0.7.1
 - Fix dark color applying incorrectly with premultiplied alpha (using draw functions)

--- a/src/animation_state.rs
+++ b/src/animation_state.rs
@@ -751,11 +751,12 @@ impl TrackEntry {
         delay,
         f32
     );
-    c_accessor!(
+    c_accessor_mut!(
         /// Current time in seconds this track entry has been the current track entry. The track
         /// time determines [`animation_time`](`Self::animation_time`). The track time can be set
         /// to start the animation at a time other than 0, without affecting looping.
         track_time,
+        set_track_time,
         trackTime,
         f32
     );

--- a/src/animation_state.rs
+++ b/src/animation_state.rs
@@ -756,6 +756,7 @@ impl TrackEntry {
         /// time determines [`animation_time`](`Self::animation_time`). The track time can be set
         /// to start the animation at a time other than 0, without affecting looping.
         track_time,
+        /// Set the track time, see [`track_time`](`Self::track_time`).
         set_track_time,
         trackTime,
         f32


### PR DESCRIPTION
Official [docs](https://en.esotericsoftware.com/spine-api-reference#TrackEntry) and the doc comments in the code mention that the TrackEntry's track time should be mutable.  This PR uses the `c_accessor_mut` macro for that field.