### PR TITLE
fix read inherit timeline; fix spBone_updateWorldTransformWith

### DIFF
--- a/src/c/spine_c.rs
+++ b/src/c/spine_c.rs
@@ -11418,7 +11418,13 @@ pub unsafe extern "C" fn spBone_updateWorldTransformWith(
             let mut za: c_float = (pa * cosine + pb * sine) / sx;
             let mut zc: c_float = (pc * cosine + pd * sine) / sy;
             let mut s_0: c_float = spine_sqrtf(za * za + zc * zc);
-            if (*(*self_0).data).inherit as c_uint == SP_INHERIT_NOSCALE as c_int as c_uint
+            if s_0 as c_double > 0.00001f64 {
+                s_0 = 1 as c_int as c_float / s_0;
+            }
+            za *= s_0;
+            zc *= s_0;
+            s_0 = spine_sqrtf(za * za + zc * zc);
+            if (*self_0).inherit as c_uint == SP_INHERIT_NOSCALE as c_int as c_uint
                 && (pa * pd - pb * pc < 0 as c_int as c_float) as c_int
                     != ((sx < 0 as c_int as c_float) as c_int
                         != (sy < 0 as c_int as c_float) as c_int) as c_int
@@ -22374,7 +22380,7 @@ unsafe extern "C" fn _spSkeletonJson_readAnimation(
                         );
                         let mut value: *const c_char = Json_getString(
                             keyMap,
-                            (b"value\0" as *const u8).cast::<c_char>(),
+                            (b"inherit\0" as *const u8).cast::<c_char>(),
                             (b"normal\0" as *const u8).cast::<c_char>(),
                         );
                         let mut inherit: spInherit = SP_INHERIT_NORMAL;


### PR DESCRIPTION
I found two issues with bone inheritance in the process of using the rust runtime, and they were fixed according to the official  c runtime.