### PR TITLE
add failing test for set_dark_color setup-pose crash

### DIFF
--- a/src/slot.rs
+++ b/src/slot.rs
@@ -315,3 +315,30 @@ impl From<spBlendMode> for BlendMode {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{test::TestAsset, Color};
+
+    #[test]
+    fn set_dark_color_then_setup_pose_repro() {
+        let (mut skeleton, _) = TestAsset::spineboy().instance(true);
+        skeleton.set_to_setup_pose();
+
+        let slot_index = skeleton
+            .slots()
+            .enumerate()
+            .find_map(|(index, slot)| slot.dark_color().is_none().then_some(index))
+            .expect("missing slot without dark color");
+
+        let mut slot = skeleton
+            .slot_at_index_mut(slot_index)
+            .expect("missing slot by index");
+        assert!(slot.data().dark_color().is_none());
+
+        slot.set_dark_color(Color::new_rgba(0.12, 0.18, 0.24, 1.0));
+        assert!(slot.dark_color().is_some());
+
+        slot.set_to_setup_pose();
+    }
+}


### PR DESCRIPTION
## Summary
- add a unit test that reproduces the crash when `set_dark_color` is used on a slot without setup dark color and then `set_to_setup_pose()` is called
- document the exact repro path in code by asserting the setup slot has no dark color, setting one at runtime, and triggering setup pose
- keep scope minimal to support follow-up fix work on top of PR #41

## Repro Test
- `slot::test::set_dark_color_then_setup_pose_repro`
- currently crashes with SIGSEGV, which is the behavior we want to capture before fixing